### PR TITLE
Quote variable expansions

### DIFF
--- a/rsauth
+++ b/rsauth
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-CREDS=$(cat /dev/stdin)
+CREDS="$(cat /dev/stdin)"
 
 if [ -z "$CREDS" ]; then
   echo "No creds provided to STDIN"
   exit 3
 fi
 
-USERNAME=$(echo ${CREDS} | cut -d' ' -f1)
-APIKEY=$(echo ${CREDS} | cut -d' ' -f2)
+USERNAME="$(echo "${CREDS}" | cut -d' ' -f1)"
+APIKEY="$(echo "${CREDS}" | cut -d' ' -f2)"
 
-TOKEN=$(curl -s https://identity.api.rackspacecloud.com/v2.0/tokens \
+TOKEN="$(curl -s https://identity.api.rackspacecloud.com/v2.0/tokens \
   -X POST \
   -d "{\"auth\":{\"RAX-KSKEY:apiKeyCredentials\":{\"username\":\"$USERNAME\", \"apiKey\":\"$APIKEY\"}}}" \
-  -H "Content-Type: application/json" | jq -r '.access.token.id // empty')
+  -H "Content-Type: application/json" | jq -r '.access.token.id // empty')"
 
 if [ -n "$TOKEN" ]; then
   exit 0


### PR DESCRIPTION
Prevents inputs like `/*/*/*` from globbing
